### PR TITLE
remove tarball directory recursively

### DIFF
--- a/libraries/provider_install.rb
+++ b/libraries/provider_install.rb
@@ -194,6 +194,7 @@ class ElasticsearchCookbook::InstallProvider < Chef::Provider::LWRPBase
 
     # remove the specific version
     d_r = directory "#{new_resource.dir}/elasticsearch-#{new_resource.version}" do
+      recursive true
       action :nothing
     end
     d_r.run_action(:delete)


### PR DESCRIPTION
Using remove action on elasticsearch installed from tarball is causing Chef failure.

That is why usage of the recursive property of the Chef directory resource is beeing proposed by this request.

Some logging info about the problem follows below:

```
elasticsearch_install 'elasticsearch' do
  type 'tarball'
  version node['elasticsearch']['version']
  action :remove
end

```

```
      ================================================================================
      Error executing action `delete` on resource 'directory[/usr/share/elasticsearch-5.2.0]'
      ================================================================================

      Errno::ENOTEMPTY
      ----------------
      Directory not empty @ dir_s_rmdir - /usr/share/elasticsearch-5.2.0

      Cookbook Trace:
      ---------------
      /home/adminsrv/chef/.chef/local-mode-cache/cache/cookbooks/elasticsearch/libraries/provider_install.rb:199:in `remove_tarball_wrapper_action'
      /home/adminsrv/chef/.chef/local-mode-cache/cache/cookbooks/elasticsearch/libraries/provider_install.rb:27:in `block in <class:InstallProvider>'

      Resource Declaration:
      ---------------------
      # In /home/adminsrv/chef/.chef/local-mode-cache/cache/cookbooks/elasticsearch/libraries/provider_install.rb

      196:     d_r = directory "#{new_resource.dir}/elasticsearch-#{new_resource.version}" do
      197:       action :nothing
      198:     end
      199:     d_r.run_action(:delete)

```